### PR TITLE
Resolve memory leak problem in CustomGalleryActivity

### DIFF
--- a/src/com/luminous/pick/CustomGalleryActivity.java
+++ b/src/com/luminous/pick/CustomGalleryActivity.java
@@ -14,6 +14,7 @@ import android.os.Handler;
 import android.os.Looper;
 import android.provider.MediaStore;
 import android.view.View;
+import android.view.ViewGroup;
 import android.view.Window;
 import android.widget.AdapterView;
 import android.widget.Button;
@@ -210,5 +211,28 @@ public class CustomGalleryActivity extends Activity {
 		Collections.reverse(galleryList);
 		return galleryList;
 	}
-
+	
+	@Override
+	protected void onDestroy() {
+		releaseDrawables(gridGallery);
+		super.onDestroy();
+	}
+	
+	private void releaseDrawables(View view) {
+		if (view == null) return;
+		
+		if ( view instanceof ImageView ) {
+			((ImageView) view).setImageDrawable(null);
+		}
+		
+		if ( view.getBackground() != null ) {
+			view.getBackground().setCallback( null );
+		}
+		
+		if ( view instanceof ViewGroup ) {
+			for (int i = 0; i < ((ViewGroup)view).getChildCount(); i++) {
+				releaseDrawables(((ViewGroup)view).getChildAt(i) );
+			}
+		}
+	}
 }


### PR DESCRIPTION
I found that memory leak occurs when I repeat action that I move to CustomGalleryActivity and go back to MainActivity by using Eclipse DDMS View's Heap monitoring.
The reason was that images(drawables), which are shown in the screen at the moment that back-button pressed,are not properly collected by GC
So I added the codes that close the connection between views and drawables so that drawables are collected well by GC.

Thank you. 
 